### PR TITLE
Add docs for API and MCP server modules

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,13 @@
+"""
+FastAPI server providing STT, chat completion and TTS endpoints.
+
+Endpoints:
+- `/` serves the demo page.
+- `/transcribe` converts uploaded audio to text.
+- `/speak` engages GPT, uses MCP tools if needed, and returns text with speech.
+- `/log` records client log messages.
+"""
+
 from fastapi import FastAPI, Request, UploadFile, File
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles

--- a/mcp_demo/mcp_server.py
+++ b/mcp_demo/mcp_server.py
@@ -1,3 +1,10 @@
+"""
+Minimal MCP server exposing tools via a JSON-RPC interface.
+
+Tools are registered in `TOOL_REGISTRY` mapping method names to callables.
+The `/mcp` endpoint dispatches incoming requests to the appropriate tool.
+"""
+
 from fastapi import FastAPI, Request
 from .tools import time_tool
 from .mcp_schema import MCPRequest, MCPResponse


### PR DESCRIPTION
## Summary
- document endpoints and purpose in `main.py`
- explain MCP server usage and tool registry in `mcp_demo/mcp_server.py`

## Testing
- `python3 -m compileall -q .`
- `python3 -m pip install -r requirements.txt` *(fails: externally-managed-environment)*

------
https://chatgpt.com/codex/tasks/task_e_684bfde7263c832892428c4f72b63f23