### PR TITLE
Add async HTTP test for MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ curl -X POST http://localhost:8001/mcp \
      -d '{"jsonrpc":"2.0","method":"get_current_time","params":{},"id":"1"}'
 ```
 
+## 테스트
+
+`pytest` 명령으로 테스트를 실행할 수 있습니다.
+
+```bash
+pytest
+```
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,25 @@
+import re
+import os
+import sys
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from mcp_demo.mcp_server import app
+
+@pytest.mark.asyncio
+async def test_get_current_time():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as ac:
+        payload = {
+            "jsonrpc": "2.0",
+            "method": "get_current_time",
+            "params": {},
+            "id": "1"
+        }
+        resp = await ac.post("/mcp", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "result" in data
+    assert "time" in data["result"]
+    assert re.match(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}", data["result"]["time"])


### PR DESCRIPTION
## Summary
- add pytest for MCP `/mcp` endpoint using httpx
- document running tests in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bfdf5e3c48328bc5e90e89bef0236